### PR TITLE
add access_at and search_at

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,15 +2,19 @@
 #
 # Table name: users
 #
-#  id          :integer          not null, primary key
-#  uid         :string(191)      not null
-#  screen_name :string(191)      not null
-#  authorized  :boolean          default(TRUE), not null
-#  secret      :string(191)      not null
-#  token       :string(191)      not null
-#  email       :string(191)      default(""), not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id              :integer          not null, primary key
+#  uid             :string(191)      not null
+#  screen_name     :string(191)      not null
+#  authorized      :boolean          default(TRUE), not null
+#  secret          :string(191)      not null
+#  token           :string(191)      not null
+#  email           :string(191)      default(""), not null
+#  first_access_at :datetime
+#  last_access_at  :datetime
+#  first_search_at :datetime
+#  last_search_at  :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 # Indexes
 #

--- a/app/models/visitor.rb
+++ b/app/models/visitor.rb
@@ -2,13 +2,15 @@
 #
 # Table name: visitors
 #
-#  id          :integer          not null, primary key
-#  session_id  :string(191)      not null
-#  user_id     :integer          default(-1), not null
-#  uid         :string(191)      default("-1"), not null
-#  screen_name :string(191)      default(""), not null
-#  created_at  :datetime         not null
-#  updated_at  :datetime         not null
+#  id              :integer          not null, primary key
+#  session_id      :string(191)      not null
+#  user_id         :integer          default(-1), not null
+#  uid             :string(191)      default("-1"), not null
+#  screen_name     :string(191)      default(""), not null
+#  first_access_at :datetime
+#  last_access_at  :datetime
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
 #
 # Indexes
 #

--- a/app/workers/create_search_log_worker.rb
+++ b/app/workers/create_search_log_worker.rb
@@ -6,11 +6,30 @@ class CreateSearchLogWorker
     log = SearchLog.new(attrs)
     log.assign_attributes(landing: landing_page?(log), first_time: first_time_session?(log))
     log.save!
+
+    if log.user_id != -1
+      user = User.find(log.user_id)
+      assign_timestamp(user, :first_access_at, log.created_at, :>)
+      assign_timestamp(user, :last_access_at, log.created_at, :<)
+
+      if log.action == 'show' && user.uid.to_i == log.uid.to_i
+        assign_timestamp(user, :first_search_at, log.created_at, :>)
+        assign_timestamp(user, :last_search_at, log.created_at, :<)
+      end
+
+      user.save! if user.changed?
+    end
   rescue => e
     logger.warn "#{e.class}: #{e.message} #{attrs.inspect}"
   end
 
   private
+
+  def assign_timestamp(user, attr, value, less_or_greater)
+    if user[attr].nil? || user[attr].send(less_or_greater, value)
+      user[attr] = value
+    end
+  end
 
   def landing_page?(log)
     log.device_type != 'crawler' && log.session_id != '-1' && !log.referer.start_with?('https://egotter.com') &&

--- a/db/migrate/20160101161524_devise_create_users.rb
+++ b/db/migrate/20160101161524_devise_create_users.rb
@@ -1,12 +1,16 @@
 class DeviseCreateUsers < ActiveRecord::Migration
   def change
     create_table(:users) do |t|
-      t.string  :uid,         null: false
-      t.string  :screen_name, null: false
-      t.boolean :authorized,  null: false, default: true
-      t.string  :secret,      null: false
-      t.string  :token,       null: false
-      t.string  :email,       null: false, default: ''
+      t.string   :uid,             null: false
+      t.string   :screen_name,     null: false
+      t.boolean  :authorized,      null: false, default: true
+      t.string   :secret,          null: false
+      t.string   :token,           null: false
+      t.string   :email,           null: false, default: ''
+      t.datetime :first_access_at, null: true
+      t.datetime :last_access_at,  null: true
+      t.datetime :first_search_at, null: true
+      t.datetime :last_search_at,  null: true
 
       t.timestamps null: false
     end

--- a/db/migrate/20161107051154_create_visitors.rb
+++ b/db/migrate/20161107051154_create_visitors.rb
@@ -1,10 +1,12 @@
 class CreateVisitors < ActiveRecord::Migration
   def change
     create_table :visitors do |t|
-      t.string  :session_id,  null: false
-      t.integer :user_id,     null: false, default: -1, index: true
-      t.string  :uid,         null: false, default: -1, index: true
-      t.string  :screen_name, null: false, default: '', index: true
+      t.string   :session_id,      null: false
+      t.integer  :user_id,         null: false, default: -1, index: true
+      t.string   :uid,             null: false, default: -1, index: true
+      t.string   :screen_name,     null: false, default: '', index: true
+      t.datetime :first_access_at, null: true
+      t.datetime :last_access_at,  null: true
 
       t.timestamps null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -390,14 +390,18 @@ ActiveRecord::Schema.define(version: 20161122144612) do
   add_index "user_retention_stats", ["date"], name: "index_user_retention_stats_on_date", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
-    t.string   "uid",         limit: 191,                null: false
-    t.string   "screen_name", limit: 191,                null: false
-    t.boolean  "authorized",              default: true, null: false
-    t.string   "secret",      limit: 191,                null: false
-    t.string   "token",       limit: 191,                null: false
-    t.string   "email",       limit: 191, default: "",   null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.string   "uid",             limit: 191,                null: false
+    t.string   "screen_name",     limit: 191,                null: false
+    t.boolean  "authorized",                  default: true, null: false
+    t.string   "secret",          limit: 191,                null: false
+    t.string   "token",           limit: 191,                null: false
+    t.string   "email",           limit: 191, default: "",   null: false
+    t.datetime "first_access_at"
+    t.datetime "last_access_at"
+    t.datetime "first_search_at"
+    t.datetime "last_search_at"
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
   end
 
   add_index "users", ["created_at"], name: "index_users_on_created_at", using: :btree
@@ -462,12 +466,14 @@ ActiveRecord::Schema.define(version: 20161122144612) do
   add_index "visitor_retention_stats", ["date"], name: "index_visitor_retention_stats_on_date", unique: true, using: :btree
 
   create_table "visitors", force: :cascade do |t|
-    t.string   "session_id",  limit: 191,                null: false
-    t.integer  "user_id",     limit: 4,   default: -1,   null: false
-    t.string   "uid",         limit: 191, default: "-1", null: false
-    t.string   "screen_name", limit: 191, default: "",   null: false
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.string   "session_id",      limit: 191,                null: false
+    t.integer  "user_id",         limit: 4,   default: -1,   null: false
+    t.string   "uid",             limit: 191, default: "-1", null: false
+    t.string   "screen_name",     limit: 191, default: "",   null: false
+    t.datetime "first_access_at"
+    t.datetime "last_access_at"
+    t.datetime "created_at",                                 null: false
+    t.datetime "updated_at",                                 null: false
   end
 
   add_index "visitors", ["created_at"], name: "index_visitors_on_created_at", using: :btree

--- a/lib/tasks/users.rake
+++ b/lib/tasks/users.rake
@@ -6,4 +6,32 @@ namespace :users do
       User.where(uid: uids_array).update_all(authorized: false)
     end
   end
+
+  desc 'update first_access_at and last_access_at'
+  task update_first_access_at_and_last_access_at: :environment do
+    search_logs = SearchLog.where(user_id: User.pluck(:id)).order(created_at: :asc)
+    users = User.where(id: search_logs.pluck(:user_id)).index_by { |u| u.id }
+
+    search_logs.each do |log|
+      user = users[log.user_id]
+      user.assign_attributes(last_access_at: log.created_at)
+      user.assign_attributes(first_access_at: log.created_at) if user.first_access_at.nil?
+    end
+
+    User.import users.values.select(&:changed?), on_duplicate_key_update: %i(first_access_at last_access_at), validate: false, timestamps: false
+  end
+
+  desc 'update first_search_at and last_search_at'
+  task update_first_search_at_and_last_search_at: :environment do
+    search_logs = SearchLog.where(user_id: User.pluck(:id), action: 'show').order(created_at: :asc)
+    users = User.where(id: search_logs.pluck(:user_id)).index_by { |u| u.id }
+
+    search_logs.each do |log|
+      user = users[log.user_id]
+      user.assign_attributes(last_search_at: log.created_at)
+      user.assign_attributes(first_search_at: log.created_at) if user.first_search_at.nil?
+    end
+
+    User.import users.values.select(&:changed?), on_duplicate_key_update: %i(first_search_at last_search_at), validate: false, timestamps: false
+  end
 end


### PR DESCRIPTION
```
alter table users
  add column first_access_at datetime after email,
  add column last_access_at datetime after first_access_at,
  add column first_search_at datetime after last_access_at,
  add column last_search_at datetime after first_search_at;
```

```
alter table visitors
  change column created_at first_access_at datetime,
  change column updated_at last_access_at datetime;

alter table visitors
  add column created_at datetime not null after last_access_at,
  add column updated_at datetime not null after created_at;

alter table visitors
  drop index index_visitors_on_created_at,
  add index index_visitors_on_created_at(created_at);
```

```
be rake visitors:copy_from_first_access_at_to_created_at
be rake users:update_first_access_at_and_last_access_at
be rake users:update_first_search_at_and_last_search_at
```