### PR TITLE
add via, bouncing and exiting to search_logs

### DIFF
--- a/app/controllers/concerns/logging.rb
+++ b/app/controllers/concerns/logging.rb
@@ -23,6 +23,7 @@ module Concerns::Logging
       cache_hit:   cache_hit,
       ego_surfing: user_signed_in? && current_user.uid.to_i == uid.to_i,
       method:      request.method,
+      via:         params[:via] ? params[:via] : '',
       device_type: request.device_type,
       os:          request.os,
       browser:     request.browser,
@@ -32,6 +33,8 @@ module Concerns::Logging
       channel:     find_channel(referral),
       first_time:  false,
       landing:     false,
+      bouncing:    false,
+      exiting:     false,
       medium:      params[:medium] ? params[:medium] : '',
       ab_test:     params[:ab_test] ? params[:ab_test] : '',
       created_at:  Time.zone.now

--- a/app/models/search_log.rb
+++ b/app/models/search_log.rb
@@ -11,6 +11,7 @@
 #  cache_hit   :boolean          default(FALSE), not null
 #  ego_surfing :boolean          default(FALSE), not null
 #  method      :string(191)      default(""), not null
+#  via         :string(191)      default(""), not null
 #  device_type :string(191)      default(""), not null
 #  os          :string(191)      default(""), not null
 #  browser     :string(191)      default(""), not null
@@ -20,6 +21,8 @@
 #  channel     :string(191)      default(""), not null
 #  first_time  :boolean          default(FALSE), not null
 #  landing     :boolean          default(FALSE), not null
+#  bouncing    :boolean          default(FALSE), not null
+#  exiting     :boolean          default(FALSE), not null
 #  medium      :string(191)      default(""), not null
 #  ab_test     :string(191)      default(""), not null
 #  created_at  :datetime         not null

--- a/config/initializers/schema_dumper.rb
+++ b/config/initializers/schema_dumper.rb
@@ -1,1 +1,1 @@
-ActiveRecord::SchemaDumper.ignore_tables = %w(blazer_audits blazer_checks blazer_dashboard_queries blazer_dashboards blazer_queries)
+ActiveRecord::SchemaDumper.ignore_tables = %w(latest_search_logs blazer_audits blazer_checks blazer_dashboard_queries blazer_dashboards blazer_queries)

--- a/db/migrate/20160109124820_create_search_logs.rb
+++ b/db/migrate/20160109124820_create_search_logs.rb
@@ -10,6 +10,7 @@ class CreateSearchLogs < ActiveRecord::Migration
       t.boolean :cache_hit,   null: false, default: false
       t.boolean :ego_surfing, null: false, default: false
       t.string  :method,      null: false, default: ''
+      t.string  :via,         null: false, default: ''
 
       t.string  :device_type, null: false, default: ''
       t.string  :os,          null: false, default: ''
@@ -21,6 +22,8 @@ class CreateSearchLogs < ActiveRecord::Migration
 
       t.boolean :first_time,  null: false, default: false
       t.boolean :landing,     null: false, default: false
+      t.boolean :bouncing,    null: false, default: false
+      t.boolean :exiting,     null: false, default: false
       t.string  :medium,      null: false, default: ''
       t.string  :ab_test,     null: false, default: ''
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -222,37 +222,6 @@ ActiveRecord::Schema.define(version: 20170220075811) do
   add_index "friendships", ["from_id", "friend_uid"], name: "index_friendships_on_from_id_and_friend_uid", unique: true, using: :btree
   add_index "friendships", ["from_id"], name: "index_friendships_on_from_id", using: :btree
 
-  create_table "latest_search_logs", force: :cascade do |t|
-    t.string   "session_id",  limit: 191, default: "",    null: false
-    t.integer  "user_id",     limit: 4,   default: -1,    null: false
-    t.string   "uid",         limit: 191, default: "",    null: false
-    t.string   "screen_name", limit: 191, default: "",    null: false
-    t.string   "action",      limit: 191, default: "",    null: false
-    t.boolean  "cache_hit",               default: false, null: false
-    t.boolean  "ego_surfing",             default: false, null: false
-    t.string   "method",      limit: 191, default: "",    null: false
-    t.string   "device_type", limit: 191, default: "",    null: false
-    t.string   "os",          limit: 191, default: "",    null: false
-    t.string   "browser",     limit: 191, default: "",    null: false
-    t.string   "user_agent",  limit: 191, default: "",    null: false
-    t.string   "referer",     limit: 191, default: "",    null: false
-    t.string   "referral",    limit: 191, default: "",    null: false
-    t.string   "channel",     limit: 191, default: "",    null: false
-    t.boolean  "first_time",              default: false, null: false
-    t.boolean  "landing",                 default: false, null: false
-    t.string   "medium",      limit: 191, default: "",    null: false
-    t.string   "ab_test",     limit: 191, default: "",    null: false
-    t.datetime "created_at",                              null: false
-  end
-
-  add_index "latest_search_logs", ["action"], name: "index_search_logs_on_action", using: :btree
-  add_index "latest_search_logs", ["created_at"], name: "index_search_logs_on_created_at", using: :btree
-  add_index "latest_search_logs", ["screen_name"], name: "index_search_logs_on_screen_name", using: :btree
-  add_index "latest_search_logs", ["session_id"], name: "index_search_logs_on_session_id", using: :btree
-  add_index "latest_search_logs", ["uid", "action"], name: "index_search_logs_on_uid_and_action", using: :btree
-  add_index "latest_search_logs", ["uid"], name: "index_search_logs_on_uid", using: :btree
-  add_index "latest_search_logs", ["user_id"], name: "index_search_logs_on_user_id", using: :btree
-
   create_table "mentions", force: :cascade do |t|
     t.string   "uid",         limit: 191,   null: false
     t.string   "screen_name", limit: 191,   null: false
@@ -414,6 +383,7 @@ ActiveRecord::Schema.define(version: 20170220075811) do
     t.boolean  "cache_hit",               default: false, null: false
     t.boolean  "ego_surfing",             default: false, null: false
     t.string   "method",      limit: 191, default: "",    null: false
+    t.string   "via",         limit: 191, default: "",    null: false
     t.string   "device_type", limit: 191, default: "",    null: false
     t.string   "os",          limit: 191, default: "",    null: false
     t.string   "browser",     limit: 191, default: "",    null: false
@@ -423,6 +393,8 @@ ActiveRecord::Schema.define(version: 20170220075811) do
     t.string   "channel",     limit: 191, default: "",    null: false
     t.boolean  "first_time",              default: false, null: false
     t.boolean  "landing",                 default: false, null: false
+    t.boolean  "bouncing",                default: false, null: false
+    t.boolean  "exiting",                 default: false, null: false
     t.string   "medium",      limit: 191, default: "",    null: false
     t.string   "ab_test",     limit: 191, default: "",    null: false
     t.datetime "created_at",                              null: false


### PR DESCRIPTION
```
alter table search_logs
  add column via varchar(191) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' after method,
  add column bouncing tinyint(1) NOT NULL DEFAULT '0' after landing,
  add column exiting tinyint(1) NOT NULL DEFAULT '0' after bouncing;
```