### PR TITLE
add enqueued_at, started_at and finished_at on background_search_logs

### DIFF
--- a/app/helpers/workers_helper.rb
+++ b/app/helpers/workers_helper.rb
@@ -24,7 +24,8 @@ module WorkersHelper
       referral:    referral,
       channel:     find_channel(referral),
       medium:      params[:medium] ? params[:medium] : '',
-      queued_at:   Time.zone.now
+      queued_at:   Time.zone.now,
+      enqueued_at: Time.zone.now
     }
 
     if user_signed_in?

--- a/app/models/background_search_log.rb
+++ b/app/models/background_search_log.rb
@@ -23,6 +23,9 @@
 #  referral    :string(191)      default(""), not null
 #  channel     :string(191)      default(""), not null
 #  medium      :string(191)      default(""), not null
+#  enqueued_at :datetime
+#  started_at  :datetime
+#  finished_at :datetime
 #  created_at  :datetime         not null
 #
 # Indexes

--- a/db/migrate/20160117142535_create_background_search_logs.rb
+++ b/db/migrate/20160117142535_create_background_search_logs.rb
@@ -24,8 +24,9 @@ class CreateBackgroundSearchLogs < ActiveRecord::Migration
       t.string  :channel,     null: false, default: ''
       t.string  :medium,      null: false, default: ''
 
-      t.datetime :queued_at,  null: true,  default: nil
-      t.datetime :started_at, null: true,  default: nil
+      t.datetime :enqueued_at, null: true,  default: nil
+      t.datetime :started_at,  null: true,  default: nil
+      t.datetime :finished_at, null: true,  default: nil
 
       t.datetime :created_at, null: false
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,6 +62,9 @@ ActiveRecord::Schema.define(version: 20170222055518) do
     t.string   "referral",    limit: 191,   default: "",    null: false
     t.string   "channel",     limit: 191,   default: "",    null: false
     t.string   "medium",      limit: 191,   default: "",    null: false
+    t.datetime "enqueued_at"
+    t.datetime "started_at"
+    t.datetime "finished_at"
     t.datetime "created_at",                                null: false
   end
 


### PR DESCRIPTION
```
alter table background_search_logs
  add column enqueued_at datetime DEFAULT NULL after medium,
  add column started_at datetime DEFAULT NULL after enqueued_at,
  add column finished_at datetime DEFAULT NULL after started_at;
```

```
Query OK, 0 rows affected (28.92 sec)
Records: 0  Duplicates: 0  Warnings: 0
```